### PR TITLE
build(npm-snapshot): use latest version of official npm-snapshot [MRF-81493]

### DIFF
--- a/providers/analytics/publish/main.js
+++ b/providers/analytics/publish/main.js
@@ -43,7 +43,7 @@ try {
 
     execStep(
         [
-            `npx github:dominguezcelada/npm-snapshot ${buildNumber} snapshot`,
+            `npx npm-snapshot ${buildNumber} snapshot`,
             `npm publish`
         ],
         '🚀 Publishing Analytics 📦 Package 📦...'

--- a/providers/jsonloadercli/publish/main.js
+++ b/providers/jsonloadercli/publish/main.js
@@ -20,7 +20,7 @@ try {
 
     execStep(
         [
-            `npx github:dominguezcelada/npm-snapshot ${buildNumber} snapshot`,
+            `npx npm-snapshot ${buildNumber} snapshot`,
             `npm publish`
         ],
         '🚀 Publishing jsonloader-cli 📦 Package 📦...'

--- a/providers/widget/publish/main.js
+++ b/providers/widget/publish/main.js
@@ -33,7 +33,7 @@ try {
 
     execStep(
         [
-            `npx github:dominguezcelada/npm-snapshot ${buildNumber} snapshot`,
+            `npx npm-snapshot ${buildNumber} snapshot`,
             `npm publish`
         ],
         '🚀Publishing widget 📦Package📦...'


### PR DESCRIPTION
- Latest version of `npm-snapshot` contains changes from oscard0m's fork
- dominguezceladas's fork does not exist anymore
