### PR TITLE
common-publish

### DIFF
--- a/common/actions/publish/action.yml
+++ b/common/actions/publish/action.yml
@@ -1,0 +1,6 @@
+# action.yml
+name: 'Publish'
+description: 'Publishing package'
+runs:
+  using: 'node12'
+  main: 'main.js'

--- a/common/actions/publish/main.js
+++ b/common/actions/publish/main.js
@@ -23,7 +23,7 @@ try {
             `npx npm-snapshot ${buildNumber} snapshot`,
             `npm publish`
         ],
-        '🚀 Publishing jsonloader-cli 📦 Package 📦...'
+        '🚀 Publishing 📦 Package 📦...'
     );
 
 } catch (error) {

--- a/providers/jsonloadercli/publish/action.yml
+++ b/providers/jsonloadercli/publish/action.yml
@@ -1,6 +1,6 @@
 # action.yml
-name: 'Publish'
-description: 'Publishing package'
+name: 'Initialize'
+description: 'Installing packages'
 runs:
   using: 'node12'
-  main: 'main.js'
+  main: '../../../common/actions/pubilsh/main.js'


### PR DESCRIPTION
now several packages are using the publish action from jsonloadercli because it's quite generic
exapmple: https://github.com/Marfeel/react-amphtml/blob/master/.github/workflows/build.yml#L36

I need this config again for publishing a package, so I'm proposing to move it to common so from other repos we can import it like
```yml
- name: 🚀 Publish
        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
        uses: Marfeel/github-actions/common/actions/publish@master
        with:
          nexus-token: ${{ secrets.NPM_NEXUS_AUTH }}
          build-number: ${{ github.run_id }}
```