### PR TITLE
define inputs for providers/widget

### DIFF
--- a/providers/widget/publish/action.yml
+++ b/providers/widget/publish/action.yml
@@ -1,6 +1,19 @@
 # action.yml
 name: 'Publish'
 description: 'Publishing widget source code to gh-packages and catalog to gh-pages'
+inputs:
+  gh-token:
+    description: 'github token'
+    required: true
+    default: ''
+  nexus-token:
+    description: 'nexus token'
+    required: true
+    default: ''
+  build-number:
+    description: 'build number'
+    required: true
+    default: 0
 runs:
   using: 'node12'
   main: 'main.js'


### PR DESCRIPTION
saw that we always get this warning when publishing widget providers packages

<img width="817" alt="Screen Shot 2022-01-24 at 3 30 43 PM" src="https://user-images.githubusercontent.com/20967825/150801979-5913e6d1-a06f-4053-96c0-a081881f8757.png">
